### PR TITLE
Change private repo to public one in guide docs

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -7,14 +7,14 @@ To run AthenaX, you need to build both AthenaX and Flink. They require Java 8 an
 ### Build AthenaX
 
 ```bash
-$ git clone git@github.com:uber/AthenaX.git
+$ git clone https://github.com/uber/AthenaX.git
 $ mvn clean install
 ```
 
 ### Build Flink
 
 ```bash
-$ git clone git@github.com:apache/flink.git
+$ git clone https://github.com/apache/flink.git
 $ mvn clean install
 ```
 


### PR DESCRIPTION
I couldn't access to repo in guide docs because of permission issue, so changed to the one in github.
Also, in configuration entry table there are item name `filnk.uber.jar.location`, but I'm not sure `filnk` is typo error or not.
Please look on. Thanks.