### PR TITLE
Remove the stale links in the documentation.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,5 +16,9 @@ Then simply run `make docs`.
 Raise a PR on GitHub. Once the PR is approved and merged,
 ask one of Athenax maintainers to kick off the build on [readthedocs](https://readthedocs.org/projects/athenax/).
 
+## Quick Start
+
+Please see [here](getting_started.md).
+
 [doc-img]: https://readthedocs.org/projects/athenax/badge/?version=latest
 [doc]: http://athenax.readthedocs.org/en/latest/

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,9 +24,6 @@ If you can't find what you are looking for, we'd love to hear from you either on
 
 We published a [blog post](https://eng.uber.com/athenax) to describe the design and architecture of AthenaX.
 
-## Quick Start
-See [running a docker all in one image](getting_started.md#all-in-one-docker-image).
-
 ## Related links
 - [Introducing AthenaX, Uber Engineering’s Open Source Streaming Analytics Platform](https://eng.uber.com/athenax/)
 


### PR DESCRIPTION
This PR removes the stale Quick start link in the documentation to avoid confusions.